### PR TITLE
Fix gradio error when run demo.

### DIFF
--- a/requirements_web_demo.txt
+++ b/requirements_web_demo.txt
@@ -1,6 +1,6 @@
 # Core dependencies
-gradio==4.42.0
-gradio_client==1.3.0
+gradio==5.4.0
+gradio_client==1.4.2
 qwen-vl-utils==0.0.2
 transformers-stream-generator==0.0.4
 torch==2.4.0


### PR DESCRIPTION
before is: 
```
pydantic.errors.PydanticSchemaGenerationError: 
Unable to generate pydantic-core schema for <class 'starlette.requests.Request'>. 
Set `arbitrary_types_allowed=True` in the model_config to ignore this error or 
implement `__get_pydantic_core_schema__` on your type to fully support it
```

After upgrade pip's requirments
its ok.
<img width="1011" alt="image" src="https://github.com/user-attachments/assets/77a01143-a583-4834-bfd5-3170c355c0dc">
