### PR TITLE
Enhance compatibility on message format.

### DIFF
--- a/qwen-vl-utils/src/qwen_vl_utils/vision_process.py
+++ b/qwen-vl-utils/src/qwen_vl_utils/vision_process.py
@@ -343,7 +343,7 @@ def extract_vision_info(conversations: list[dict] | list[list[dict]]) -> list[di
                         "image" in ele
                         or "image_url" in ele
                         or "video" in ele
-                        or ele["type"] in ("image", "image_url", "video")
+                        or ele.get("type","") in ("image", "image_url", "video")
                     ):
                         vision_infos.append(ele)
     return vision_infos


### PR DESCRIPTION
For ```{"text": "..."}```, this line of code will raise an Exception. It should not assume that the content element contains a "type".