### PR TITLE
fix a bug of smart_resize

### DIFF
--- a/qwen-vl-utils/src/qwen_vl_utils/vision_process.py
+++ b/qwen-vl-utils/src/qwen_vl_utils/vision_process.py
@@ -77,8 +77,8 @@ def smart_resize(
     w_bar = max(factor, round_by_factor(width, factor))
     if h_bar * w_bar > max_pixels:
         beta = math.sqrt((height * width) / max_pixels)
-        h_bar = floor_by_factor(height / beta, factor)
-        w_bar = floor_by_factor(width / beta, factor)
+        h_bar = max(factor, floor_by_factor(height / beta, factor))
+        w_bar = max(factor, floor_by_factor(width / beta, factor))
     elif h_bar * w_bar < min_pixels:
         beta = math.sqrt(min_pixels / (height * width))
         h_bar = ceil_by_factor(height * beta, factor)


### PR DESCRIPTION
I found a corner case that will make smart_resize fail,
```python
import PIL.Image as Image
from qwen_vl_utils import process_vision_info

image = Image.new("RGB", (31, 639), color=(255, 255, 255))

messages = [
    {
        "role": "user",
        "content": [
            {
                "type": "image",
                "image": image,
                "max_pixels": 20 * 28 * 28,
            },
            {"type": "text", "text": "Describe this image."}
        ]
    }
]
image_inputs, video_inputs = process_vision_info(messages)
```
In this case, smart_resize will resize the image to `(0, 560)`, which causes a bug: `"height must be > 0"`. This is because when the image_size exceeds max_pixel, and one side is close to 28 pixels, after being processed by `floor_by_factor` in `smart_resize`, it becomes 0. Therefore, I submitted this PR to fix the bug.
