### PR TITLE
Fix `get_data` and `_get_item` functions using redundant parameters while training with text only data.

### DIFF
--- a/qwen-vl-finetune/qwenvl/data/data_qwen.py
+++ b/qwen-vl-finetune/qwenvl/data/data_qwen.py
@@ -444,10 +444,9 @@ class LazySupervisedDataset(Dataset):
             second_per_grid_ts=second_per_grid_ts if second_per_grid_ts else None,
         )
         if "image" not in sources[0] and "video" not in sources[0]:
-            grid_thw_merged = None
             sources = copy.deepcopy([e["conversations"] for e in sources])
             data_dict = preprocess_qwen_2_visual(
-                sources, self.tokenizer, grid_thw=grid_thw_merged
+                sources, self.tokenizer
             )
             position_ids = (
                 torch.arange(0, data_dict["input_ids"].size(1))

--- a/qwen-vl-finetune/qwenvl/data/data_qwen_packed.py
+++ b/qwen-vl-finetune/qwenvl/data/data_qwen_packed.py
@@ -444,10 +444,9 @@ class LazySupervisedDataset(Dataset):
             second_per_grid_ts=second_per_grid_ts if second_per_grid_ts else None,
         )
         if "image" not in sources[0] and "video" not in sources[0]:
-            grid_thw_merged = None
             sources = copy.deepcopy([e["conversations"] for e in sources])
             data_dict = preprocess_qwen_2_visual(
-                sources, self.tokenizer, grid_thw=grid_thw_merged
+                sources, self.tokenizer
             )
             position_ids = (
                 torch.arange(0, data_dict["input_ids"].size(1))


### PR DESCRIPTION
The data pipeline code had an unexpected parameter while SFT qwen2vl with text only dataset.
It seems the program parses the `grid_thw` parameter to the `preprocess_qwen_2_visual ` function, while this parameter has been assigned a none value and also a outdated parameter for the function.