### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Below, we provide simple examples to show how to use Qwen2.5-VL with 🤖 ModelS
 
 The code of Qwen2.5-VL has been in the latest Hugging face transformers and we advise you to build from source with command:
 ```
-pip install git+https://github.com/huggingface/transformers accelerate
+pip install transformers==4.51.3 accelerate
 ```
 or you might encounter the following error:
 ```


### PR DESCRIPTION
because the transformers new dev version dont support qwen2.5_vl
Is we use the old command
"pip install git+https://github.com/huggingface/transformers accelerate"
we will get the transformers==4.52.0.dev0
but it can't run 
```py
processor = AutoProcessor.from_pretrained("Qwen/Qwen2.5-VL-7B-Instruct")
```
it will cause some new error
```
ValueError: Could not find Qwen2_5_VLVideoProcessor neither in <module 'transformers.models.qwen2_5_vl' from '/home/creeponsky/miniconda3/envs/data-p/lib/python3.10/site-packages/transformers/models/qwen2_5_vl/__init__.py'> nor in <module 'transformers' from '/home/creeponsky/miniconda3/envs/data-p/lib/python3.10/site-packages/transformers/__init__.py'>!
```

so, just use 4.51.3!
