### PR TITLE
Fix missing padding_side=left for batch inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,7 @@ inputs = processor(
     images=image_inputs,
     videos=video_inputs,
     padding=True,
+    padding_side="left",
     return_tensors="pt",
 )
 inputs = inputs.to("cuda")


### PR DESCRIPTION
This PR fixes an issue in the Batch Inference example in README.md, where the padding_side="left" parameter was missing.

For decoder-only LLMs (e.g., GPT-style models), it's important to set padding_side to "left" during batch inference. Without this setting, the model may behave unexpectedly or generate incorrect outputs, e.g., #759 
 
This change ensures the example runs correctly and avoids confusion for users.