### PR TITLE
[BUG FIX] Fix truncation of position_ids in DataCollatorForSupervisedDataset

### DIFF
--- a/qwen-vl-finetune/qwenvl/data/data_qwen.py
+++ b/qwen-vl-finetune/qwenvl/data/data_qwen.py
@@ -510,7 +510,7 @@ class DataCollatorForSupervisedDataset(object):
         position_ids = pad_and_cat(position_ids)
         input_ids = input_ids[:, : self.tokenizer.model_max_length]
         labels = labels[:, : self.tokenizer.model_max_length]
-        position_ids = position_ids[:, : self.tokenizer.model_max_length]
+        position_ids = position_ids[:, :, : self.tokenizer.model_max_length]
         batch = dict(
             input_ids=input_ids,
             labels=labels,


### PR DESCRIPTION
The trunction of `position_ids` to `self.tokenizer.model_max_length` in `DataCollatorForSupervisedDataset` is wrong. This PR fixes this bug.

### Evidence

Here is the current code for the truncation:

```python
position_ids = pad_and_cat(position_ids)
input_ids = input_ids[:, : self.tokenizer.model_max_length]
labels = labels[:, : self.tokenizer.model_max_length]
position_ids = position_ids[:, : self.tokenizer.model_max_length]
```

Let's take a look at the `pad_and_cat` function:

```
def pad_and_cat(tensor_list):
    max_length = max(tensor.shape[2] for tensor in tensor_list)

    padded_tensors = []
    for tensor in tensor_list:
        pad_length = max_length - tensor.shape[2]
        padded_tensor = torch.nn.functional.pad(tensor, (0, pad_length), "constant", 1)
        padded_tensors.append(padded_tensor)

    stacked_tensor = torch.cat(padded_tensors, dim=1)

    return stacked_tensor
```

We can see that the expected dimensions for the `position_ids` Tensor are (3, B, N) where B is the batch size and N the sequence length. This is also visible in the code that creates the tensor, in `get_rope_index_25`:

```
        position_ids = torch.ones(
            3,
            input_ids.shape[0],
            input_ids.shape[1],
            dtype=input_ids.dtype,
            device=input_ids.device,
        )
```

However the `position_ids` are truncated along the dimension 1 (i.e. the batch size dimension) instead of the dimension 2 (sequence length):

```
position_ids = position_ids[:, : self.tokenizer.model_max_length]
```

instead of

```
position_ids = position_ids[:, :, :, self.tokenizer.model_max_length]
```

In practice, this causes an error when some inputs are longer than the max sequence length. The error arises in the `apply_multimodal_rotary_pos_emb` function which applies the RoPE embeddings. Example with a sequence of length 1098 for a max_sequence_length of 1024:

```
[rank5]: file "/.../.local/lib/python3.12/site-packages/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py", line 683, in apply_multimodal_rotary_pos_emb
[rank5]: q_embed = (q * cos) + (rotate_half(q) * sin)
[rank5]:
[rank5]: RuntimeError: The size of tensor a (1024) must match the size of tensor b (1098) at non-singleton dimension 2
```